### PR TITLE
Make project build on CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/minimed-connect-to-nightscout
+    docker:
+      - image: circleci/node:8.11.3
+    steps:
+      - checkout
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@5'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: npm-install
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: run-tests
+          command: npm test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "0.10.x"
+    "node": "8.x",
+    "npm": "5.x"
   },
   "dependencies": {
     "common": "0.2.x",


### PR DESCRIPTION
CircleCI is deprecating their 1.0 platform in less than two months. This CircleCI 2.0-compatible configuration ensures that the project will continue to build.