### PR TITLE
Dev v.1.3.2

### DIFF
--- a/carelink.js
+++ b/carelink.js
@@ -90,7 +90,7 @@ var Client = exports.Client = function (options) {
       CARELINK_SECURITY_URL,
       reqOptions({
         jar: jar,
-        qs: {j_username: options.username, j_password: options.password}
+        form: {j_username: options.username, j_password: options.password, j_character_encoding: "UTF-8"}
       }),
       checkResponseThen(next)
     );


### PR DESCRIPTION
MiniMed Connect error: Bad response from CareLink

MiniMed Connect error: Error: Bad response from CareLink: 
data for login should be send in body.
If data for login are in address "https://carelink.minimed.eu/patient/j_security_check?j_username=XXX&j_password=YYY", application send response "Bad Request page".
When the address is 'https://carelink.minimed.eu/patient/j_security_check' and post body =  "j_username=XXX&j_password=YYY" all is ok.
j_character_encoding: "UTF-8" I add becouse careapplication put this in post body.